### PR TITLE
fix errant case of not using `context.data` when sending the response…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fluvial-^$#root",
-	"version": "0.6.3",
+	"version": "0.6.4",
 	"description": "Fluvial:  A light http/2 server framework, similar to Express",
 	"main": "dist/index.js",
 	"private": true,

--- a/packages/cookies/package.json
+++ b/packages/cookies/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluvial/cookies",
-	"version": "0.6.3",
+	"version": "0.6.4",
 	"description": "A cookie management library for Fluvial",
 	"exports": {
 		".": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fluvial",
-	"version": "0.6.3",
+	"version": "0.6.4",
 	"description": "Fluvial:  A light http/2 server framework, similar to Express",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -343,7 +343,7 @@ export class FluvialResponse extends Writable implements Fluvial.__InternalRespo
 			await callback(sendContext);
 		}
 		
-		const bytes = Buffer.isBuffer(sendContext.data) ? sendContext.data : typeof data == 'string' ? Buffer.from(sendContext.data) : Buffer.from([]);
+		const bytes = Buffer.isBuffer(sendContext.data) ? sendContext.data : typeof sendContext.data == 'string' ? Buffer.from(sendContext.data) : Buffer.from([]);
 		
 		if (bytes.byteLength && !this.headers['content-length']) {
 			this.headers['content-length'] = String(bytes.byteLength);

--- a/packages/cors/package.json
+++ b/packages/cors/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluvial/cors",
-	"version": "0.6.3",
+	"version": "0.6.4",
 	"main": "dist/index.js",
 	"files": [
 		"dist/**/*",

--- a/packages/csp/package.json
+++ b/packages/csp/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluvial/csp",
-	"version": "0.6.3",
+	"version": "0.6.4",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"files": [

--- a/packages/express-adapter/package.json
+++ b/packages/express-adapter/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluvial/express-adapter",
-	"version": "0.6.3",
+	"version": "0.6.4",
 	"main": "dist/index.js",
 	"files": [
 		"dist/**/*",


### PR DESCRIPTION
…, then bump to 0.6.4 for bugfix