### PR TITLE
fix bug for express-to-fluvial adapter to include query string in `url`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fluvial-^$#root",
-	"version": "0.6.4",
+	"version": "0.6.5",
 	"description": "Fluvial:  A light http/2 server framework, similar to Express",
 	"main": "dist/index.js",
 	"private": true,

--- a/packages/cookies/package.json
+++ b/packages/cookies/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluvial/cookies",
-	"version": "0.6.4",
+	"version": "0.6.5",
 	"description": "A cookie management library for Fluvial",
 	"exports": {
 		".": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fluvial",
-	"version": "0.6.4",
+	"version": "0.6.5",
 	"description": "Fluvial:  A light http/2 server framework, similar to Express",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/cors/package.json
+++ b/packages/cors/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluvial/cors",
-	"version": "0.6.4",
+	"version": "0.6.5",
 	"main": "dist/index.js",
 	"files": [
 		"dist/**/*",

--- a/packages/csp/package.json
+++ b/packages/csp/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluvial/csp",
-	"version": "0.6.4",
+	"version": "0.6.5",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"files": [

--- a/packages/express-adapter/package.json
+++ b/packages/express-adapter/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluvial/express-adapter",
-	"version": "0.6.4",
+	"version": "0.6.5",
 	"main": "dist/index.js",
 	"files": [
 		"dist/**/*",

--- a/packages/express-adapter/src/to-fluvial.ts
+++ b/packages/express-adapter/src/to-fluvial.ts
@@ -1,3 +1,4 @@
+import { URLSearchParams } from 'node:url';
 import { Request as ExpressRequest, Response as ExpressResponse, NextFunction } from 'express';
 import { Request as FluvialRequest, Response as FluvialResponse } from 'fluvial';
 
@@ -49,7 +50,12 @@ function wrapForFluvial(
 					return target.payload || {};
 				}
 				if (property == 'url' || property == 'originalUrl') {
-					return target.path;
+					let url = target.path;
+					const query = new URLSearchParams(target.query);
+					if (query.size) {
+						url += `?${query}`;
+					}
+					return url;
 				}
 				
 				if (property in target) {


### PR DESCRIPTION
…+ bump version to 0.6.5